### PR TITLE
fix: `pnpm` dependencies

### DIFF
--- a/packages/create-remdx/template/package.json
+++ b/packages/create-remdx/template/package.json
@@ -3,9 +3,14 @@
   "version": "0.0.1",
   "type": "module",
   "dependencies": {
+    "@mdx-js/mdx": "^2.3.0",
     "@nkzw/remdx": "*",
+    "gray-matter": "^4.0.3",
+    "normalize-newline": "^4.1.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "rehype-raw": "^6.1.1",
+    "remark-shiki-twoslash": "^3.1.3"
   },
   "devDependencies": {
     "@nkzw/vite-plugin-remdx": "*",


### PR DESCRIPTION
Had to manually add these dependencies after choosing `pnpm`. Furthermore, I've faced this issue afterwards, that I'm not 100% where it is coming from.

<img width="912" alt="image" src="https://github.com/cpojer/remdx/assets/19473034/6d1d8f95-dfdb-40ca-b62e-0004b7a640ea">
