### PR TITLE
fix: add .gitignore to create-remdx template

### DIFF
--- a/packages/create-remdx/template/.gitignore
+++ b/packages/create-remdx/template/.gitignore
@@ -1,0 +1,6 @@
+.eslintcache
+.pnpm-debug.log
+/node_modules/
+coverage/
+dist/
+tsconfig.tsbuildinfo


### PR DESCRIPTION
Referenced from: https://github.com/nkzw-tech/dev-velocity-talk/blob/main/.gitignore

Closes https://github.com/cpojer/remdx/issues/9