### PR TITLE
Add .re.mdx type declaration files

### DIFF
--- a/packages/create-remdx/template/remdx-env.d.ts
+++ b/packages/create-remdx/template/remdx-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@nkzw/remdx/client.d.ts" />

--- a/packages/create-remdx/template/tsconfig.json
+++ b/packages/create-remdx/template/tsconfig.json
@@ -27,5 +27,5 @@
     "target": "es2022"
   },
   "exclude": ["dist/", "node_modules"],
-  "include": ["**/*.ts", "**/*.tsx"]
+  "include": ["remdx-env.d.ts", "**/*.ts", "**/*.tsx"]
 }

--- a/packages/remdx/client.d.ts
+++ b/packages/remdx/client.d.ts
@@ -1,9 +1,7 @@
-import type { MDXComponents, ReMDXSlide, Themes } from './types';
-
 declare module '*.re.mdx' {
-  let slides: ReadonlyArray<ReMDXSlide>;
+  let slides: ReadonlyArray<import('./types.jsx').ReMDXSlide>;
 
-  export let Components: MDXComponents | undefined;
-  export let Themes: Themes | undefined;
+  export let Components: import('./types.jsx').MDXComponents | undefined;
+  export let Themes: import('./types.jsx').Themes | undefined;
   export default slides;
 }

--- a/packages/remdx/src/deck.tsx
+++ b/packages/remdx/src/deck.tsx
@@ -6,17 +6,12 @@ import {
   useEffect,
 } from 'react';
 import { SwipeEventData } from 'react-swipeable';
+import { SlideTransition } from '../types.tsx';
 import useAspectRatioFitting from './hooks/use-aspect-ratio-fitting.tsx';
 import useDeckState from './hooks/use-deck-state.tsx';
 import useLocationSync from './hooks/use-location-sync.tsx';
 import useMousetrap from './hooks/use-mousetrap.tsx';
 import { defaultTransition } from './transitions.tsx';
-
-export type SlideTransition = {
-  enter?: CSSProperties;
-  from?: CSSProperties;
-  leave?: CSSProperties;
-};
 
 type DeckContextType = {
   activeView: {

--- a/packages/remdx/src/slide.tsx
+++ b/packages/remdx/src/slide.tsx
@@ -9,7 +9,8 @@ import {
 } from 'react';
 import { animated, useSpring } from 'react-spring';
 import { useSwipeable } from 'react-swipeable';
-import { DeckContext, SlideTransition } from './deck.tsx';
+import { SlideTransition } from '../types.tsx';
+import { DeckContext } from './deck.tsx';
 import { GOTO_FINAL_STEP } from './hooks/use-deck-state.tsx';
 import { Transitions } from './transitions.tsx';
 

--- a/packages/remdx/src/transitions.tsx
+++ b/packages/remdx/src/transitions.tsx
@@ -1,4 +1,4 @@
-import { SlideTransition } from './deck.tsx';
+import { SlideTransition } from '../types.tsx';
 
 export const defaultTransition: SlideTransition = {
   enter: {

--- a/packages/remdx/types.tsx
+++ b/packages/remdx/types.tsx
@@ -1,6 +1,5 @@
 import { MDXProvider } from '@mdx-js/react';
 import { CSSProperties } from 'react';
-import { SlideTransition } from './src/deck.tsx';
 
 type MDXProps =
   typeof MDXProvider extends React.FC<infer Props> ? Props : never;
@@ -16,6 +15,5 @@ export type ReMDXSlide = {
 export type ReMDXModule = {
   Components?: MDXComponents;
   Themes?: Themes;
-  Transitions?: Record<string, SlideTransition>;
   default: ReadonlyArray<ReMDXSlide>;
 };

--- a/packages/remdx/types.tsx
+++ b/packages/remdx/types.tsx
@@ -1,8 +1,33 @@
-import { MDXProvider } from '@mdx-js/react';
 import { CSSProperties } from 'react';
 
-type MDXProps =
-  typeof MDXProvider extends React.FC<infer Props> ? Props : never;
+/**
+ * Configuration for `MDXProvider`.
+ */
+type MDXProps = {
+  /**
+   * Children (optional).
+   */
+  children?: ReactNode | null | undefined;
+  /**
+   * Additional components to use or a function that creates them (optional).
+   */
+  components?: Readonly<MDXComponents> | MergeComponents | null | undefined;
+  /**
+   * Turn off outer component context (default: `false`).
+   */
+  disableParentContext?: boolean | null | undefined;
+};
+
+/**
+ * Provider for MDX context.
+ *
+ * @param {Readonly<MDXProps>} properties
+ *   Properties.
+ * @returns {JSX.Element}
+ *   Element.
+ * @satisfies {Component}
+ */
+function MDXProvider(properties: Readonly<MDXProps>): JSX.Element;
 
 export type MDXComponents = MDXProps['components'];
 export type Themes = Record<string, CSSProperties>;

--- a/packages/remdx/types.tsx
+++ b/packages/remdx/types.tsx
@@ -32,6 +32,12 @@ function MDXProvider(properties: Readonly<MDXProps>): JSX.Element;
 export type MDXComponents = MDXProps['components'];
 export type Themes = Record<string, CSSProperties>;
 
+export type SlideTransition = {
+  enter?: CSSProperties;
+  from?: CSSProperties;
+  leave?: CSSProperties;
+};
+
 export type ReMDXSlide = {
   Component: () => JSX.Element;
   data: Record<string, string>;
@@ -40,5 +46,6 @@ export type ReMDXSlide = {
 export type ReMDXModule = {
   Components?: MDXComponents;
   Themes?: Themes;
+  Transitions?: Record<string, SlideTransition>;
   default: ReadonlyArray<ReMDXSlide>;
 };


### PR DESCRIPTION
Closes #2

I looked at the Next.js [global image types](https://github.com/vercel/next.js/blob/canary/packages/next/image-types/global.d.ts) and [type declaration `next-env.d.ts`](https://github.com/vercel/next.js/blob/canary/packages/create-next-app/templates/app/ts/next-env.d.ts) and played around with the `@nkzw/remdx/client.d.ts` and `@nkzw/remdx/types.tsx` files, came up with this suggestion here

It unfortunately removes the import of `SlideTransition` from the ([unpublished](https://www.npmjs.com/package/@nkzw/remdx?activeTab=code)) `'./src/deck.tsx'` file, so that will need to be fixed before merging