### PR TITLE
Import JSX to avoid tsc namespace error

### DIFF
--- a/packages/remdx/types.tsx
+++ b/packages/remdx/types.tsx
@@ -15,12 +15,12 @@ export type SlideContainer = ({
   children,
   style,
 }: {
-  children: JSX.Element;
+  children: React.JSX.Element;
   style: CSSProperties;
 }) => ReactNode;
 
 export type ReMDXSlide = Readonly<{
-  Component: () => JSX.Element;
+  Component: () => React.JSX.Element;
   data: Record<string, string>;
 }>;
 

--- a/packages/remdx/types.tsx
+++ b/packages/remdx/types.tsx
@@ -1,5 +1,5 @@
 import type { useMDXComponents } from '@mdx-js/react';
-import type { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties, JSX, ReactNode } from 'react';
 
 export type MDXComponents = Parameters<typeof useMDXComponents>[0];
 
@@ -15,12 +15,12 @@ export type SlideContainer = ({
   children,
   style,
 }: {
-  children: React.JSX.Element;
+  children: JSX.Element;
   style: CSSProperties;
 }) => ReactNode;
 
 export type ReMDXSlide = Readonly<{
-  Component: () => React.JSX.Element;
+  Component: () => JSX.Element;
   data: Record<string, string>;
 }>;
 


### PR DESCRIPTION
To avoid type error with not being able to find `JSX` namespace

```bash
$ tsc

Error: node_modules/@nkzw/remdx/types.tsx(18,13): error TS2503: Cannot find namespace 'JSX'.
Error: node_modules/@nkzw/remdx/types.tsx(23,20): error TS2503: Cannot find namespace 'JSX'.
```

My original approach used the `React` global:

```diff
-JSX
+React.JSX
```

But there's already an import from `'react'`, so it seems simpler to add to that.