### PR TITLE
Set title with <title> element and React 19 RC

### DIFF
--- a/packages/create-remdx/template/index.html
+++ b/packages/create-remdx/template/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>ReMDX</title>
+    <title>Loading...</title>
     <meta
       name="viewport"
       content="width=device-width, user-scalable=no, initial-scale=1, viewport-fit=cover"

--- a/packages/create-remdx/template/package.json
+++ b/packages/create-remdx/template/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "dependencies": {
     "@nkzw/remdx": "*",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "rc",
+    "react-dom": "rc"
   },
   "devDependencies": {
     "@nkzw/vite-plugin-remdx": "*",

--- a/packages/create-remdx/template/slides.re.mdx
+++ b/packages/create-remdx/template/slides.re.mdx
@@ -9,6 +9,8 @@ image: tokyo.jpg
 
 --
 
+<title>ReMDX - Tokyo Demo</title>
+
 # Welcome to ReMDX
 
 ---


### PR DESCRIPTION
Hey @cpojer, hope you're good!

Not sure whether this is a desired approach for ReMDX, but using [Support for Document Metadata](https://react.dev/blog/2024/04/25/react-19#support-for-metadata-tags) from the React 19 RC, it's possible to use a `<title>` element to keep the slide show title in the `.mdx` file.

(especially useful if using [a single `public/index.html` file for multiple slide decks](https://github.com/nkzw-tech/remdx/issues/11#issuecomment-1937087998)) 

Here's a video:


https://github.com/user-attachments/assets/2b5d17df-2502-41f2-9f34-ba2c02942ebd

