### PR TITLE
Allow for multi-line imports and exports

### DIFF
--- a/packages/vite-plugin-remdx/index.ts
+++ b/packages/vite-plugin-remdx/index.ts
@@ -10,7 +10,7 @@ import ColorReplacements from './lib/ColorReplacements.tsx';
 type Slide = [string, Record<string, unknown>];
 
 const EXPORT_DEFAULT_REGEXP = /export\sdefault\s/g;
-const MODULE_REGEXP = /\\`|`(?:\\`|[^`])*`|(^(?:import|export).*$)/gm;
+const MODULE_REGEXP = /\\`|`(?:\\`|[^`])*`|(^(?:import|export)[^;]+;)/gm;
 
 const compileMDX = async (
   content: string,


### PR DESCRIPTION
Currently ReMDX crashes with a misleading Acorn error message when a multi-line `export` such as the following is present in a `slides.re.mdx` file:

`slides.re.mdx`

```mdx
export { Components } from '../../Components.tsx';
export { Themes } from '../../Themes.tsx';

export const metadata = {
  title: 'REST APIs',
};

# REST APIs
```

Error message:

```
[plugin:mdx-transform] Could not parse import/exports with acorn
/Users/k/p/courses/packages/slide-decks/slideDecks/rest-apis/slides.re.mdx:11:2
9  |  export { Themes } from '../../Themes.tsx';
10 |  
11 |  export const metadata = {
   |    ^
12 |    title: 'REST APIs',
13 |  };
```

![Screenshot 2024-08-12 at 14 52 44](https://github.com/user-attachments/assets/e120b26a-aaf7-4893-ab76-c5cff06f1c92)

This first led me to believe that it was a bug in `@mdx-js/mdx`, but MDX itself can handle multi-line imports with no problems.

I eventually narrowed it down to the regular expression which matches `import` and `export` statements, which is currently constrained to single-line statements.

This PR allows for multi-line `import` and `export` statements, by matching non-`;` characters up until the first `;`