### PR TITLE
Fixed __dirname ReferenceError in create-remdx

### DIFF
--- a/packages/create-remdx/index.tsx
+++ b/packages/create-remdx/index.tsx
@@ -11,7 +11,6 @@ import { blue, bold, dim, green, yellow } from 'kolorist';
 import prompts from 'prompts';
 
 const argv = require('minimist')(process.argv.slice(2));
-const __dirname = import.meta.dirname;
 const cwd = process.cwd();
 
 async function create() {
@@ -52,7 +51,7 @@ async function create() {
 
   console.log(dim('  Scaffolding project in ') + targetDir + dim(' ...'));
 
-  const templateDir = path.join(__dirname, 'template');
+  const templateDir = path.join(import.meta.dirname, 'template');
 
   const write = (file: string, content?: string) => {
     const targetPath = path.join(root, file);

--- a/packages/create-remdx/index.tsx
+++ b/packages/create-remdx/index.tsx
@@ -11,6 +11,7 @@ import { blue, bold, dim, green, yellow } from 'kolorist';
 import prompts from 'prompts';
 
 const argv = require('minimist')(process.argv.slice(2));
+const __dirname = import.meta.dirname;
 const cwd = process.cwd();
 
 async function create() {


### PR DESCRIPTION
Running `npm init remdx` fails with:
```
ReferenceError: __dirname is not defined
```
## Issue details

The script uses `__dirname`, which exists only in CommonJS scope. Since the package is configured as an ES module, `__dirname` doesn't exist.

## Solution

Solved with `import.meta.dirname`  ( available for Node.js v20.11+ or v21.2+ )