### PR TITLE
Style `<code>` in headings, improve contrast of white text

### DIFF
--- a/packages/remdx/style.css
+++ b/packages/remdx/style.css
@@ -88,7 +88,7 @@
     --sc-background-color-light: rgb(73, 128, 209, 0.1);
     --sc-background-color: rgb(20, 20, 20);
     --sc-background-color-layer: rgb(38 38 38);
-    --sc-inline-code-background-color: rgb(39, 39, 39);
+    --sc-inline-code-background-color: rgb(32, 32, 32);
     --sc-line-highlight-color: #c2e8ff35;
     --sc-line-number-color: #adadad;
     --sc-link-color: rgb(94 159 255);
@@ -257,6 +257,12 @@ pre code .line::before {
   color: var(--sc-line-number-color);
 }
 
+h1 > code,
+h2 > code,
+h3 > code,
+h4 > code,
+h5 > code,
+h6 > code,
 p code,
 li > code,
 li a > code,


### PR DESCRIPTION
One of the patches that I still have on ReMDX, which allows inline code blocks in headings, eg:

```md
## Create `users` table with `id` and `name` Fields
```

<img width="1439" height="769" alt="Screenshot 2026-02-22 at 16 53 24" src="https://github.com/user-attachments/assets/7465dfac-5c53-47f8-88ea-ce3f25652b5f" />

Also improves the contrast of white text on the background a bit, by switching from `rgb(39, 39, 39)` to  `rgb(32, 32, 32)`