### PR TITLE
Improve inline and block (Shiki) code block styling

### DIFF
--- a/packages/remdx/style.css
+++ b/packages/remdx/style.css
@@ -195,6 +195,12 @@ pre[data-title]::before {
   top: -1.2em;
 }
 
+pre.shiki {
+  border-radius: 0.25rem;
+  padding-bottom: 0.25rem;
+  padding-left: 0.25rem;
+}
+
 pre.shiki > div > a {
   display: none;
 }
@@ -255,18 +261,15 @@ pre code .line::before {
   display: inline-block;
   text-align: right;
   color: var(--sc-line-number-color);
+  padding-right: 0.125rem;
 }
 
-h1 > code,
-h2 > code,
-h3 > code,
-h4 > code,
-h5 > code,
-h6 > code,
-p code,
-li > code,
-li a > code,
-ul > code {
+code:not(:where(pre *)) {
+  border-radius: 0.25rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  font-size: 0.875em;
+  line-height: 1.4em;
   background: var(--sc-inline-code-background-color);
   overflow-wrap: anywhere;
   margin-top: -20px;

--- a/packages/remdx/style.css
+++ b/packages/remdx/style.css
@@ -196,12 +196,6 @@ pre[data-title]::before {
   top: -1.2em;
 }
 
-pre.shiki {
-  border-radius: 0.25rem;
-  padding-bottom: 0.25rem;
-  padding-left: 0.25rem;
-}
-
 pre.shiki > div > a {
   display: none;
 }

--- a/packages/remdx/style.css
+++ b/packages/remdx/style.css
@@ -1,14 +1,8 @@
 :root {
   --font-size: 36px;
-  --font-mono: 'Fira Code',
-    ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    Monaco,
-    Consolas,
-    'Liberation Mono',
-    'Courier New',
-    monospace;
+  --font-mono:
+    'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
   --text-color: #000;
   --background-color: #fff;
 

--- a/packages/remdx/style.css
+++ b/packages/remdx/style.css
@@ -174,7 +174,8 @@ pre.shiki {
   background-color: var(--sc-background-color);
   color: var(--sc-text-color);
   position: relative;
-  padding-right: 12px;
+  border-radius: 4px;
+  padding: 0 12px 4px 2px;
   font-family: 'Fira Code', monospace;
 }
 
@@ -261,13 +262,13 @@ pre code .line::before {
   display: inline-block;
   text-align: right;
   color: var(--sc-line-number-color);
-  padding-right: 0.125rem;
+  padding-right: 2px;
 }
 
 code:not(:where(pre *)) {
-  border-radius: 0.25rem;
-  padding-left: 0.25rem;
-  padding-right: 0.25rem;
+  border-radius: 4px;
+  padding-left: 4px;
+  padding-right: 4px;
   font-size: 0.875em;
   line-height: 1.4em;
   background: var(--sc-inline-code-background-color);

--- a/packages/remdx/style.css
+++ b/packages/remdx/style.css
@@ -1,5 +1,14 @@
 :root {
   --font-size: 36px;
+  --font-mono: 'Fira Code',
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    'Liberation Mono',
+    'Courier New',
+    monospace;
   --text-color: #000;
   --background-color: #fff;
 
@@ -176,7 +185,7 @@ pre.shiki {
   position: relative;
   border-radius: 4px;
   padding: 0 12px 4px 2px;
-  font-family: 'Fira Code', monospace;
+  font-family: var(--font-mono);
 }
 
 pre[data-title] {
@@ -207,7 +216,7 @@ pre.shiki .language-id {
 pre.shiki .code-title {
   background-color: var(--sc-background-color);
   color: var(--sc-comments-fg);
-  font-family: 'Fira Code', monospace;
+  font-family: var(--font-mono);
   display: inline-block;
   margin-bottom: 4px;
   margin-left: 46px;
@@ -244,7 +253,7 @@ pre.shiki code {
 pre code {
   counter-increment: step 0;
   counter-reset: step;
-  font-family: 'Fira Code', monospace;
+  font-family: var(--font-mono);
   white-space: pre;
 }
 


### PR DESCRIPTION
⚠️ Stacked on #27 

Before:

<img width="1303" height="686" alt="Screenshot 2026-02-22 at 17 27 00" src="https://github.com/user-attachments/assets/168e3a29-1e02-411f-8551-b5961b6c1d16" />


After:

<img width="1331" height="702" alt="Screenshot 2026-02-22 at 17 37 00" src="https://github.com/user-attachments/assets/b50b6bf3-87e8-4645-ae18-61d0a2d0adaa" />
